### PR TITLE
Small modification to the speech sentence exercises

### DIFF
--- a/app/src/main/assets/textExercises.csv
+++ b/app/src/main/assets/textExercises.csv
@@ -1,11 +1,11 @@
 de;es;en
 Lilo liebt lila Luftballons. Lina dagegen kann lila Luftballons nicht leiden.;Mi casa tiene tres cuartos.;My mom drove me to school fifteen minutes late on Tuesday.
-Abends übt Elsa oft auf ihrer elektronischen Orgel, und Antonio intoniert Arien aus italienischen Opern.;Omar que vive cerca trajo miel.;The tape got stuck on my lips so I couldn't talk anymore.
+Im Inhaltsverzeichnis stand nichts über Lindenblütentee.;Omar que vive cerca trajo miel.;The tape got stuck on my lips so I couldn't talk anymore.
 Es reiten dreiunddreißig Reiter flott und munter den Berg dreiunddreißigmal hinauf und herunter.;Laura sube al tren que pasa.;My shoes are blue with yellow stripes and green stars on the front.
 Peter und Paul essen gerne Pudding.;Los libros nuevos no caben en la mesa de la oficina.;I was so thirsty I couldn't wait to get a drink of water.
 Das Fest war sehr gut vorbereitet.;Rosita Niño, que pinta bien, donó sus cuadros ayer.;I found a gold coin on the playground after school today.
 Seit seiner Hochzeit hat er sich sehr verändert.;Luisa Rey compra el colchón duro que tanto le gusta.;The chocolate chip cookies smelled so good that I ate one without asking.
-Im Inhaltsverzeichnis stand nichts über Lindenblütentee.;Viste las noticias? Yo vi ganar la medalla de plata en pesas. ¡Ese muchacho tiene mucha fuerza!;I was so scared to go to a monster movie but my dad said he would sit with me so we went last night.
+Abends übt Elsa oft auf ihrer elektronischen Orgel, und Antonio intoniert Arien aus italienischen Opern.;Viste las noticias? Yo vi ganar la medalla de plata en pesas. ¡Ese muchacho tiene mucha fuerza!;I was so scared to go to a monster movie but my dad said he would sit with me so we went last night.
 Der Kerzenständer fiel gemeinsam mit der Blumenvase auf den Plattenspieler.; Juan se rompió una pierna cuando iba en la moto.;The school principal was so mean that all the children were scared of him.
 Einst stritten sich die Sonne und der Wind, wer von ihnen beiden der Stärkere sei.;Estoy muy triste, ayer vi morir a un amigo.;The camping trip was so awesome that I didn't want to come home.
 Sogleich begann der Wind zu stürmen; Regen und Hagelschauer unterstützten ihn.;Estoy muy preocupado, cada vez me es más difícil hablar!;That boy is so mean that he doesn't care if a door slams in your face or if he cuts in line.


### PR DESCRIPTION
The longest sentence for German, Spanish, and English now have the same ID (7).  This is done to "measure" the intonation as good as possible.